### PR TITLE
Fix seed overflow and add pipeline cache eviction

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -150,6 +150,7 @@ def _load_pipeline(
 
     pipeline = _PIPELINE_CACHE.get(cache_key)
     if pipeline is not None:
+        _PIPELINE_CACHE.move_to_end(cache_key)
         return pipeline
 
     optimum_intel_path = _find_parent_path("optimum-intel", "optimum")

--- a/nodes.py
+++ b/nodes.py
@@ -186,6 +186,7 @@ def _load_pipeline(
         int(pe_max_new_tokens),
     )
     _PIPELINE_CACHE[cache_key] = pipeline
+    _PIPELINE_CACHE.move_to_end(cache_key)
     while len(_PIPELINE_CACHE) > _PIPELINE_CACHE_MAX_SIZE:
         _PIPELINE_CACHE.popitem(last=False)
     return pipeline

--- a/nodes.py
+++ b/nodes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections import OrderedDict
 from pathlib import Path
 from typing import Optional
 
@@ -56,7 +57,8 @@ def _default_model_dir() -> Path | None:
 DEFAULT_MODEL_DIR = _default_model_dir()
 
 
-_PIPELINE_CACHE = {}
+_PIPELINE_CACHE_MAX_SIZE = 2
+_PIPELINE_CACHE: OrderedDict = OrderedDict()
 
 
 def _normalize_optional_device(value: str) -> Optional[str]:
@@ -183,6 +185,8 @@ def _load_pipeline(
         int(pe_max_new_tokens),
     )
     _PIPELINE_CACHE[cache_key] = pipeline
+    while len(_PIPELINE_CACHE) > _PIPELINE_CACHE_MAX_SIZE:
+        _PIPELINE_CACHE.popitem(last=False)
     return pipeline
 
 
@@ -254,7 +258,7 @@ class OVErnieImageTextToImage:
                         "step": 0.1,
                     },
                 ),
-                "seed": ("INT", {"default": 42, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
+                "seed": ("INT", {"default": 42, "min": 0, "max": 0x7FFFFFFFFFFFFFFF}),
             }
         }
 


### PR DESCRIPTION
Fixes #1 

**Summary:**
- Fix seed max from `0xFFFFFFFFFFFFFFFF` (2^64-1) to `0x7FFFFFFFFFFFFFFF` (2^63-1) to align perfectly with `torch.Generator.manual_seed()`'s hard backend limits. 
- Replace unbounded dictionary pipeline cache with an `OrderedDict` LRU mechanism (max 2 entries). Each ERNIE-Image pipeline consumes 2-4GB; this protects users from memory exhaustion if they are heavily experimenting traversing between multiple model sub-directories/devices in a solitary long-running ComfyUI session.
