### PR TITLE
[Enhancement] Add ruff linting to CI workflow

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -14,5 +14,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install linter
+        run: python -m pip install ruff
+      - name: Lint with ruff
+        run: python -m ruff check nodes.py scripts/
       - name: Compile Python files
         run: python -m py_compile nodes.py scripts/check_env.py scripts/verify_comfyui_api.py scripts/start_comfyui_openvino.py


### PR DESCRIPTION
Fixes #2 

**Summary:**
The `pyproject.toml` natively configures ruff styling logic, but the CI pipeline only checked for raw `py_compile` syntax. Modifying the Action pipeline strictly enforces the expected code formatting guardrails on all incoming PRs and codebase extensions going forward.
